### PR TITLE
12 separate lexer and parser

### DIFF
--- a/lib/Parser/Data/Ast.hs
+++ b/lib/Parser/Data/Ast.hs
@@ -10,6 +10,7 @@ module Parser.Data.Ast
     UnaryOp (..),
     Struct,
     Array (..),
+    Body,
   )
 where
 
@@ -31,7 +32,7 @@ data Statement
   = VariableDeclaration VariableName Type (Maybe Expression) -- let <name>: <type> = <expression>
   | FunctionDeclaration FunctionName [Field] Type Body -- fn <name>(<args>) -> <type> { <body> }
   | WhileLoop Expression Body -- while (<condition>) { <body> }
-  | Conditional Expression Body (Maybe (Expression, Body, Maybe Body)) -- if <cond> { <body> } [elif <cond> { <body> }] [else { <body> }]
+  | If Expression Body (Maybe Body) -- if <cond> { <then_body> } [else { <else_body> }] NOTE: 'elif <cond> { }' is actually else '{ if <cond> { <then_body> } }'
   | TypeDeclaration !TypeDefinition -- type <name> = <typedef>
   | ReturnStatement Expression -- return <expression>
   | ExpressionStatement Expression -- standalone expression

--- a/lib/Parser/Data/Ast.hs
+++ b/lib/Parser/Data/Ast.hs
@@ -69,9 +69,9 @@ data Primitive
 
 data Expression
   = Variable String -- variable name
-  | ELiteral Literal -- constant values
-  | BinaryOp BinOp Expression Expression -- <expr> <op> <expr>
-  | UnaryOp UnaryOp Expression -- <op> <expr>
+  | ELiteral !Literal -- constant values
+  | BinaryOp !BinOp Expression Expression -- <expr> <op> <expr>
+  | UnaryOp !UnaryOp Expression -- <op> <expr>
   | Parenthesis Expression -- (<expr>)
   | FunctionCall FunctionName [Expression] -- <func_name>(<args>)
   deriving (Show, Eq)
@@ -81,9 +81,7 @@ data Literal
     IntLiteral !Integer
   | FloatLiteral !Double
   deriving
-    ( Show,
-      Eq
-    )
+    (Show, Eq)
 
 data BinOp
   = Add -- +

--- a/lib/Parser/Data/Ast.hs
+++ b/lib/Parser/Data/Ast.hs
@@ -10,7 +10,7 @@ module Parser.Data.Ast
     UnaryOp (..),
     Struct (..),
     Array (..),
-    TypeDefinition (..),
+    EnumT (..),
     Mutablility (..),
     FunctionName,
     VariableName,
@@ -36,17 +36,10 @@ data Statement
   | FunctionDeclaration FunctionName [Field] Type Body -- fn <name>(<args>) -> <type> { <body> }
   | WhileLoop Expression Body -- while (<condition>) { <body> }
   | If Expression Body (Maybe Body) -- if <cond> { <then_body> } [else { <else_body> }] NOTE: 'elif <cond> { }' is actually else '{ if <cond> { <then_body> } }'
-  | TypeDeclaration !TypeDefinition -- type <name> = <typedef>
+  | TypeDeclaration String Type -- type <name> = <typedef>
   | ReturnStatement Expression -- return <expression>
   | StandaloneFunctionCall FunctionName [Expression] -- <func_name>(<args>)
   | VariableReAssignment VariableName Expression -- <name> = <expression>
-  deriving (Show, Eq)
-
-data TypeDefinition
-  = StructDeclaration String Struct -- { <fields> }
-  | ArrayDeclaration String (Int, Type) -- [<size>: <type>]
-  | EnumDeclaration String [String] -- <variant1, variant2, ...>
-  | AliasDeclaration String Type -- <type>
   deriving (Show, Eq)
 
 data Mutablility
@@ -55,12 +48,12 @@ data Mutablility
   deriving (Show, Eq)
 
 data Type
-  = PrimitiveType Primitive -- i8, u8, f32, etc.
-  | PointerType Mutablility Type -- `\*mut or *` <type> (True for mutable, False for immutable)
-  | StructType [Field] -- { <name>: <type>, ... }
-  | -- | ArrayType Int Type      -- [<size>: <type>]
-    -- | EnumType [String]       -- <variant1, variant2, ...>
-    CustomType String -- <name> (Must start with a capital letter)
+  = PrimitiveType !Primitive -- i8, u8, f32, etc.
+  | PointerType !Mutablility Type -- `\*mut or *` <type> (True for mutable, False for immutable)
+  | StructType !Struct -- { <name>: <type>, ... }
+  | ArrayType !Array -- [<size>: <type>]
+  | EnumType !EnumT -- <variant1, variant2, ...>
+  | CustomType !String -- <name> (Must start with a capital letter)
   deriving (Show, Eq)
 
 data Primitive
@@ -127,5 +120,8 @@ newtype Struct = Struct [Field] -- { <fields> }
   deriving (Show, Eq)
 
 -- Array
-data Array = Array Int Type -- [<size>: <type>]
+data Array = Array !Int !Type -- [<size>: <type>]
+  deriving (Show, Eq)
+
+newtype EnumT = EnumT [String] -- <variant1, variant2, ...>
   deriving (Show, Eq)

--- a/lib/Parser/Data/Ast.hs
+++ b/lib/Parser/Data/Ast.hs
@@ -18,10 +18,8 @@ module Parser.Data.Ast
   )
 where
 
-import Data.Word (Word64)
-
 newtype Program = Program [Statement]
-  deriving (Show)
+  deriving (Show, Eq)
 
 type VariableName = String
 
@@ -48,12 +46,12 @@ data Mutablility
   deriving (Show, Eq)
 
 data Type
-  = PrimitiveType !Primitive -- i8, u8, f32, etc.
-  | PointerType !Mutablility Type -- `\*mut or *` <type> (True for mutable, False for immutable)
-  | StructType !Struct -- { <name>: <type>, ... }
-  | ArrayType !Array -- [<size>: <type>]
-  | EnumType !EnumT -- <variant1, variant2, ...>
-  | CustomType !String -- <name> (Must start with a capital letter)
+  = PrimitiveType !Mutablility !Primitive -- i8, u8, f32, etc.
+  | PointerType !Mutablility Type -- `\*mut or *` <type>
+  | StructType !Mutablility !Struct -- { <name>: <type>, ... }
+  | ArrayType !Mutablility !Array -- [<size>: <type>]
+  | EnumType !Mutablility !EnumT -- <variant1, variant2, ...>
+  | CustomType !Mutablility !String -- <name> (Must start with a capital letter)
   deriving (Show, Eq)
 
 data Primitive
@@ -80,8 +78,8 @@ data Expression
 
 data Literal
   = -- | StringLiteral String
-    IntLiteral Word64
-  | FloatLiteral Double
+    IntLiteral !Integer
+  | FloatLiteral !Double
   deriving
     ( Show,
       Eq
@@ -113,6 +111,7 @@ data UnaryOp
   | AddressOf -- ?
   | Negate -- !
   | BitNot -- ~
+  | Negative -- -
   deriving (Show, Eq)
 
 -- Struct

--- a/lib/Parser/System/Lexer.hs
+++ b/lib/Parser/System/Lexer.hs
@@ -1,0 +1,320 @@
+{-# LANGUAGE TypeFamilies #-}
+
+module Parser.System.Lexer
+  ( TokenStream (..),
+    Token (..),
+    TokenType (..),
+    tokens,
+  )
+where
+
+import Data.Void
+import qualified Text.Megaparsec as MP
+import qualified Text.Megaparsec.Char as C
+import qualified Text.Megaparsec.Char.Lexer as L
+
+-- -----------------------------------------------------------------------------
+-- Token and TokenType definitions
+-- -----------------------------------------------------------------------------
+
+data Token = Token
+  { tokenPos :: !MP.SourcePos,
+    tokenType :: !TokenType
+  }
+  deriving (Eq, Ord, Show)
+
+data TokenType
+  = TLet -- 'let'
+  | TFn -- 'fn'
+  | TIf -- 'if'
+  | TElif -- 'elif'
+  | TElse -- 'else'
+  | TWhile -- 'while'
+  | TReturn -- 'return'
+  | TType -- 'type'
+  | TMut -- 'mut'
+  | TDot -- '.'
+  | TDereference -- '@'
+  | TAddressOf -- '?'
+  | TColon -- ':'
+  | TArrow -- '->'
+  | TSemicolon -- ';'
+  | TComma -- ','
+  | TEqSign -- '='
+  | TOpenParen -- '('
+  | TCloseParen -- ')'
+  | TOpenBrace -- '{'
+  | TCloseBrace -- '}'
+  | TOpenBracket -- '['
+  | TCloseBracket -- ']'
+  | TPlus -- '+'
+  | TMinus -- '-'
+  | TMult -- '*'
+  | TDiv -- '/'
+  | TMod -- '%'
+  | TAnd -- '&'
+  | TOr -- '|'
+  | TNot -- '!'
+  | TLess -- '<'
+  | TGreater -- '>'
+  | TXor -- '^'
+  | TNor -- '~'
+  | TIntLit !Integer
+  | TFloatLit !Double
+  | TIdent !String
+  | TEOF
+  deriving (Eq, Ord, Show)
+
+type Lexer = MP.Parsec Void String
+
+-------------------------------------------------------------------------------
+-- Basic helpers for parsing tokens
+-------------------------------------------------------------------------------
+
+-- Skip spaces, line comments, and block comments
+sc :: Lexer ()
+sc =
+  L.space
+    C.space1
+    (L.skipLineComment "//")
+    (L.skipBlockComment "/*" "*/")
+
+lexeme :: Lexer a -> Lexer a
+lexeme = L.lexeme sc
+
+symbol :: String -> TokenType -> Lexer Token
+symbol str ttype = lexeme $ do
+  pos <- MP.getSourcePos
+  _ <- C.string str
+  return $ Token pos ttype
+
+-- Parse a keyword but ensure it’s not followed by an identifier character
+keyword :: String -> TokenType -> Lexer Token
+keyword str ttype = lexeme . MP.try $ do
+  pos <- MP.getSourcePos
+  _ <- C.string str
+  MP.notFollowedBy C.alphaNumChar
+  return $ Token pos ttype
+
+-------------------------------------------------------------------------------
+-- Token parsers
+-------------------------------------------------------------------------------
+
+pLet :: Lexer Token
+pLet = keyword "let" TLet
+
+pFn :: Lexer Token
+pFn = keyword "fn" TFn
+
+pIf :: Lexer Token
+pIf = keyword "if" TIf
+
+pElif :: Lexer Token
+pElif = keyword "elif" TElif
+
+pElse :: Lexer Token
+pElse = keyword "else" TElse
+
+pWhile :: Lexer Token
+pWhile = keyword "while" TWhile
+
+pReturn :: Lexer Token
+pReturn = keyword "return" TReturn
+
+pType :: Lexer Token
+pType = keyword "type" TType
+
+pMut :: Lexer Token
+pMut = keyword "mut" TMut
+
+pColon :: Lexer Token
+pColon = symbol ":" TColon
+
+pArrow :: Lexer Token
+pArrow = symbol "->" TArrow
+
+pSemicolon :: Lexer Token
+pSemicolon = symbol ";" TSemicolon
+
+pComma :: Lexer Token
+pComma = symbol "," TComma
+
+pAssign :: Lexer Token
+pAssign = symbol "=" TEqSign
+
+pOpenParen :: Lexer Token
+pOpenParen = symbol "(" TOpenParen
+
+pCloseParen :: Lexer Token
+pCloseParen = symbol ")" TCloseParen
+
+pOpenBrace :: Lexer Token
+pOpenBrace = symbol "{" TOpenBrace
+
+pCloseBrace :: Lexer Token
+pCloseBrace = symbol "}" TCloseBrace
+
+pOpenBracket :: Lexer Token
+pOpenBracket = symbol "[" TOpenBracket
+
+pCloseBracket :: Lexer Token
+pCloseBracket = symbol "]" TCloseBracket
+
+pDereference :: Lexer Token
+pDereference = symbol "@" TDereference
+
+pAddressOf :: Lexer Token
+pAddressOf = symbol "?" TAddressOf
+
+pPlus :: Lexer Token
+pPlus = symbol "+" TPlus
+
+pMinus :: Lexer Token
+pMinus = symbol "-" TMinus
+
+pMult :: Lexer Token
+pMult = symbol "*" TMult
+
+pDiv :: Lexer Token
+pDiv = symbol "/" TDiv
+
+pMod :: Lexer Token
+pMod = symbol "%" TMod
+
+pAnd :: Lexer Token
+pAnd = symbol "&" TAnd
+
+pOr :: Lexer Token
+pOr = symbol "|" TOr
+
+pNot :: Lexer Token
+pNot = symbol "!" TNot
+
+pLess :: Lexer Token
+pLess = symbol "<" TLess
+
+pGreater :: Lexer Token
+pGreater = symbol ">" TGreater
+
+pXor :: Lexer Token
+pXor = symbol "^" TXor
+
+pNor :: Lexer Token
+pNor = symbol "~" TNor
+
+-- Integer and Float literals
+pIntLit :: Lexer Token
+pIntLit = lexeme $ do
+  pos <- MP.getSourcePos
+  num <- L.signed sc L.decimal
+  return $ Token pos (TIntLit num)
+
+pFloatLit :: Lexer Token
+pFloatLit = lexeme $ do
+  pos <- MP.getSourcePos
+  f <- L.signed sc L.float
+  return $ Token pos (TFloatLit f)
+
+-- Identifiers (must not match reserved keywords)
+pIdent :: Lexer Token
+pIdent = lexeme $ do
+  pos <- MP.getSourcePos
+  name <- (:) <$> C.letterChar <*> MP.many (C.alphaNumChar MP.<|> C.char '_')
+  return $ Token pos (TIdent name)
+
+pEOF :: Lexer Token
+pEOF = do
+  pos <- MP.getSourcePos
+  _ <- MP.eof
+  return $ Token pos TEOF
+
+-------------------------------------------------------------------------------
+-- Combining token parsers
+-------------------------------------------------------------------------------
+
+tokenParser :: Lexer Token
+tokenParser =
+  MP.choice
+    [ pLet,
+      pFn,
+      pIf,
+      pElif,
+      pElse,
+      pWhile,
+      pReturn,
+      pType,
+      pMut,
+      pColon,
+      pArrow,
+      pSemicolon,
+      pComma,
+      pAssign,
+      pOpenParen,
+      pCloseParen,
+      pOpenBrace,
+      pCloseBrace,
+      pOpenBracket,
+      pCloseBracket,
+      pDereference,
+      pAddressOf,
+      pIdent,
+      MP.try pFloatLit, -- try float before int
+      pPlus,
+      pMinus,
+      pMult,
+      pDiv,
+      pMod,
+      pAnd,
+      pOr,
+      pNot,
+      pLess,
+      pGreater,
+      pXor,
+      pNor,
+      pIntLit
+    ]
+
+tokens :: Lexer [Token]
+tokens = do
+  sc -- Skip initial whitespace/comments
+  ts <- MP.many tokenParser
+  eofToken <- pEOF
+  return (ts ++ [eofToken])
+
+-- -----------------------------------------------------------------------------
+-- TokenStream for Megaparsec parser
+-- -----------------------------------------------------------------------------
+
+newtype TokenStream = TokenStream {getTokenStream :: [Token]}
+  deriving (Show)
+
+instance MP.Stream TokenStream where
+  type Token TokenStream = Token
+  type Tokens TokenStream = [Token]
+
+  tokenToChunk _ t = [t]
+  tokensToChunk _ ts = ts
+  chunkToTokens _ ts = ts
+  chunkLength _ = length
+  chunkEmpty _ = null
+
+  take1_ (TokenStream []) = Nothing
+  take1_ (TokenStream (t : ts)) = Just (t, TokenStream ts)
+
+  takeN_ n (TokenStream s)
+    | n <= 0 = Just ([], TokenStream s)
+    | null s = Nothing
+    | otherwise =
+        Just (splitAt n s) >>= \(x, y) ->
+          Just (x, TokenStream y)
+
+  takeWhile_ f (TokenStream s) =
+    let (x, y) = span f s
+     in (x, TokenStream y)
+
+main :: IO ()
+main = do
+  let input = "let ifs : i32 = -422222222222.222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222;"
+  case MP.runParser tokens "<FileName>" input of
+    Left err -> putStrLn $ MP.errorBundlePretty err
+    Right ts -> print ts

--- a/lib/Parser/System/Lexer.hs
+++ b/lib/Parser/System/Lexer.hs
@@ -311,10 +311,3 @@ instance MP.Stream TokenStream where
   takeWhile_ f (TokenStream s) =
     let (x, y) = span f s
      in (x, TokenStream y)
-
-main :: IO ()
-main = do
-  let input = "let ifs : i32 = -422222222222.222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222;"
-  case MP.runParser tokens "<FileName>" input of
-    Left err -> putStrLn $ MP.errorBundlePretty err
-    Right ts -> print ts

--- a/lib/Parser/System/Lexer.hs
+++ b/lib/Parser/System/Lexer.hs
@@ -244,20 +244,20 @@ pNor = symbol "~" TNor
 pIntLit :: Lexer Token
 pIntLit = lexeme $ do
   pos <- MP.getSourcePos
-  num <- L.signed sc L.decimal
+  num <- L.decimal
   return $ Token pos (TIntLit num)
 
 pFloatLit :: Lexer Token
 pFloatLit = lexeme $ do
   pos <- MP.getSourcePos
-  f <- L.signed sc L.float
+  f <- L.float
   return $ Token pos (TFloatLit f)
 
 -- Identifiers (must not match reserved keywords)
 pIdent :: Lexer Token
 pIdent = lexeme $ do
   pos <- MP.getSourcePos
-  name <- (:) <$> C.letterChar <*> MP.many (C.alphaNumChar MP.<|> C.char '_')
+  name <- (:) <$> (C.letterChar MP.<|> C.char '_') <*> MP.many (C.alphaNumChar MP.<|> C.char '_')
   return $ Token pos (TIdent name)
 
 pEOF :: Lexer Token
@@ -303,8 +303,8 @@ tokenParser =
       pAddressOf,
       pIdent,
       MP.try pFloatLit, -- try float before int
-      pPlus,
       pMinus,
+      pPlus,
       pMult,
       pDiv,
       pMod,

--- a/lib/Parser/System/Parser.hs
+++ b/lib/Parser/System/Parser.hs
@@ -1,198 +1,429 @@
-module Parser.System.Parser where
+{-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
+module Parser.System.Parser
+  ( parseProgram,
+  )
+where
 
 import Control.Monad.Combinators.Expr
+import Data.Char (isUpper)
+import Data.Maybe (isJust)
 import Data.Void
+import Data.Word (Word64)
 import Parser.Data.Ast
-import Text.Megaparsec
-import Text.Megaparsec.Char
-import qualified Text.Megaparsec.Char.Lexer as L
+import Parser.System.Lexer (Token (..), TokenStream, TokenType (..))
+import qualified Parser.System.Lexer as Lexer
+import Text.Megaparsec hiding (Token)
 
-type Parser = Parsec Void String
 
-sc :: Parser ()
-sc = L.space space1 (L.skipLineComment "//") (L.skipBlockComment "/*" "*/")
+type Parser = Parsec Void TokenStream
 
-lexeme :: Parser a -> Parser a
-lexeme = L.lexeme sc
+-------------------------------------------------------------------------------
+-- Token Matching Helpers
+-------------------------------------------------------------------------------
 
-symbol :: String -> Parser String
-symbol = L.symbol sc
-
--- reserved keywords (return, i32, u32, ect...)
-reserved :: String -> Parser ()
-reserved w = (lexeme . try) (string w *> notFollowedBy alphaNumChar)
-
-parseInt :: Parser Literal
-parseInt = IntLiteral <$> lexeme L.decimal
-
-parseFloat :: Parser Literal
-parseFloat = FloatLiteral <$> lexeme L.float
-
-parseLiteral :: Parser Literal
-parseLiteral = try parseFloat <|> parseInt
-
-variableName :: Parser String
-variableName =
-  lexeme $
-    string "_" <|> ((:) <$> lowerChar <*> many (alphaNumChar <|> char '_'))
-
-functionName :: Parser String
-functionName = lexeme ((:) <$> (lowerChar <|> char '_') <*> many (alphaNumChar <|> char '_'))
-
-parseType :: Parser Type
-parseType = (PrimitiveType <$> parsePrimitive) <|> (CustomType <$> parseCustomType)
+-- Match a specific token type
+matchToken :: (TokenType -> Bool) -> Parser Token
+matchToken f = token testToken mempty
   where
-    parsePrimitive =
-      choice
-        [ I8 <$ reserved "i8",
-          I16 <$ reserved "i16",
-          I32 <$ reserved "i32",
-          I64 <$ reserved "i64",
-          U8 <$ reserved "u8",
-          U16 <$ reserved "u16",
-          U32 <$ reserved "u32",
-          U64 <$ reserved "u64",
-          F32 <$ reserved "f32",
-          F64 <$ reserved "f64"
-        ]
-    parseCustomType = lexeme ((:) <$> upperChar <*> many alphaNumChar)
+    testToken t@(Token _ tp)
+      | f tp = Just t
+      | otherwise = Nothing
 
-parseExpression :: Parser Expression
-parseExpression = makeExprParser term operators
-  where
-    term =
-      choice
-        [ Variable <$> variableName,
-          ELiteral <$> parseLiteral,
-          parens parseExpression
-        ]
-    operators =
-      [ [Prefix (UnaryOp Negate <$ symbol "!")],
-        [ InfixL (BinaryOp Mul <$ symbol "*"),
-          InfixL (BinaryOp Div <$ symbol "/")
-        ],
-        [ InfixL (BinaryOp Add <$ symbol "+"),
-          InfixL (BinaryOp Sub <$ symbol "-")
-        ],
-        [ InfixN (BinaryOp Eq <$ symbol "=="),
-          InfixN (BinaryOp Neq <$ symbol "!="),
-          InfixN (BinaryOp Lt <$ symbol "<"),
-          InfixN (BinaryOp Gt <$ symbol ">"),
-          InfixN (BinaryOp Le <$ symbol "<="),
-          InfixN (BinaryOp Ge <$ symbol ">=")
-        ],
-        [ InfixL (BinaryOp And <$ symbol "&&"),
-          InfixL (BinaryOp Or <$ symbol "||"),
-          InfixL (BinaryOp Mod <$ symbol "%")
-        ],
-        [ InfixL (BinaryOp BitAnd <$ symbol "&"),
-          InfixL (BinaryOp BitOr <$ symbol "|")
-        ],
-        [InfixL (BinaryOp Assign <$ symbol "=")]
-      ]
+matchTokenType :: TokenType -> Parser Token
+matchTokenType ttype = matchToken (== ttype)
 
-parens :: Parser a -> Parser a
-parens = between (symbol "(") (symbol ")")
-
-parseExpressionStatement :: Parser Statement
-parseExpressionStatement = ExpressionStatement <$> parseExpression <* symbol ";"
-
-parseStatement :: Parser Statement
-parseStatement =
-  choice
-    [ 
-      -- try parseIfStatement,
-      try parseWhileLoop,
-      try parseVariableDeclaration,
-      try parseFunctionDeclaration,
-      try parseReturnStatement,
-      parseExpressionStatement
-    ]
-
-parseWhileLoop :: Parser Statement
-parseWhileLoop = do
-  reserved "while"
-  condition <- parseExpression
-  body <- braces (many parseStatement)
-  return $ WhileLoop condition body
-
--- parseIfStatement :: Parser Statement
--- parseIfStatement = do
---   reserved "if"
---   condition <- parens parseExpression
---   thenBody <- braces (many parseStatement)
---   elseClause <- optional parseElseClause
---   return $ If condition thenBody elseClause
-
--- -- parseElseClause :: Parser Body
--- -- parseElseClause = do
--- --   reserved "else"
--- --   choice
--- --     [ try parseElseIf,
--- --       braces (many parseStatement)
--- --     ]
-
--- -- -- parseElseIf :: Parser Body
--- -- -- parseElseIf = do
--- -- --   reserved "elif"
--- -- --   condition <- parens parseExpression
--- -- --   thenBody <- braces (many parseStatement)
--- -- --   elseClause <- optional parseElseClause
--- -- --   return [ElseIf condition thenBody elseClause]
-
-parseVariableDeclaration :: Parser Statement
-parseVariableDeclaration =
-  -- withRecovery recover $
-  do
-    reserved "let"
-    name <- variableName
-    _ <- symbol ":"
-    t <- parseType
-    initializer <- optional (symbol "=" *> parseExpression)
-    _ <- symbol ";"
-    return $ VariableDeclaration name t initializer
-
-parseFunctionDeclaration :: Parser Statement
-parseFunctionDeclaration =
-  -- withRecovery recover $
-  do
-    reserved "fn"
-    name <- functionName
-    args <- parens (parseField `sepBy` symbol ",") <?> "function arguments"
-    _ <- symbol "->" <?> "'->' before return type"
-    returnType <- parseType <?> "function return type"
-    body <- braces (many parseStatement <?> "statements inside function body") <?> "function body"
-    return $ FunctionDeclaration name args returnType body
-
-parseReturnStatement :: Parser Statement
-parseReturnStatement =
-  -- withRecovery recover $
-  ReturnStatement <$> (reserved "return" *> parseExpression <* symbol ";")
-
-parseField :: Parser Field
-parseField =
-  (\name _ t -> (name, t))
-    <$> variableName
-    <*> (symbol ":" <?> "':' after field name")
-    <*> parseType
-
+-------------------------------------------------------------------------------
+-- Parse Program
+-------------------------------------------------------------------------------
 parseProgram :: Parser Program
 parseProgram = Program <$> many parseStatement
 
--- WORK IN PROGRESS
--- recover :: ParseError String Void -> Parser Statement
--- recover err = do
---   registerParseError err
---   skipManyTill anySingle (try $ lookAhead parseStatement <|> eof)
---   return $ ExpressionStatement (Variable "<error>")
+-------------------------------------------------------------------------------
+-- Parse Statements
+-------------------------------------------------------------------------------
+parseStatement :: Parser Statement
+parseStatement =
+  choice
+    [ parseVariableDeclaration,
+      parseFunctionDeclaration,
+      parseWhileLoop,
+      parseIf,
+      parseTypeDeclaration,
+      parseReturnStatement,
+      -- both parseVariable and parseStandaloneFunctionCall start with an identifier, so we need to try one first
+      try parseStandaloneFunctionCall,
+      parseVariableReAssignment
+    ]
 
-braces :: Parser a -> Parser a
-braces = between (symbol "{") (symbol "}")
+-------------------------------------------------------------------------------
+-- Variable Declaration: let <name>: <type> = <expr>;
+-------------------------------------------------------------------------------
+parseVariableDeclaration :: Parser Statement
+parseVariableDeclaration = do
+  _ <- matchTokenType TLet
+  name <- parseIdentifier
+  _ <- matchTokenType TColon
+  ty <- parseType
+  initVal <- optional (matchTokenType TEqSign *> parseExpression)
+  _ <- matchTokenType TSemicolon
+  return $ VariableDeclaration name ty initVal
 
-someMain :: IO ()
-someMain = do
-  -- let input = "let x: i32 = 42;\nfn add(a: i32, b: i32) -> i32 {\n  if a > 5 {\n    return 0;\n  } else {\n    return a + b;\n  }\n}"
-  let xinput = "fn dowhile(a: i32) -> i32 {\n  let x: i32 = 0;\n  while x < a {\n    x = x + 1;\n  }\n  return x;\n}"
-  case runParser parseProgram "<stdin>" xinput of
-    Left err -> putStrLn $ errorBundlePretty err
-    Right result -> putStrLn $ "Parsed successfully: " ++ show result
+-------------------------------------------------------------------------------
+-- Function Declaration: fn <name>(<args>) -> <type> { <body> }
+-------------------------------------------------------------------------------
+parseFunctionDeclaration :: Parser Statement
+parseFunctionDeclaration = do
+  _ <- matchTokenType TFn
+  name <- parseIdentifier
+  _ <- matchTokenType TOpenParen
+  args <- parseField `sepBy` matchTokenType TComma
+  _ <- matchTokenType TCloseParen
+  _ <- matchTokenType TArrow
+  retType <- parseType
+  body <- parseBlock
+  return $ FunctionDeclaration name args retType body
+
+-------------------------------------------------------------------------------
+-- While Loop: while <condition> { <body> }
+-------------------------------------------------------------------------------
+parseWhileLoop :: Parser Statement
+parseWhileLoop = do
+  _ <- matchTokenType TWhile
+  cond <- parseExpression
+  body <- parseBlock
+  return $ WhileLoop cond body
+
+-------------------------------------------------------------------------------
+-- If: if <cond> { <then_body> } [else { <else_body> }]
+-------------------------------------------------------------------------------
+parseIf :: Parser Statement
+parseIf = do
+  _ <- matchTokenType TIf
+  cond <- parseExpression
+  thenBody <- parseBlock
+  elifBodies <- many parseElif -- there can be no elifs
+  elseBody <- optional (matchTokenType TElse *> parseBlock)
+  return $ transformIf cond thenBody elifBodies elseBody
+
+-------------------------------------------------------------------------------
+-- Elif: elif <cond> { <body> }
+-------------------------------------------------------------------------------
+parseElif :: Parser (Expression, Body)
+parseElif = do
+  _ <- matchTokenType TElif
+  cond <- parseExpression
+  body <- parseBlock
+  return (cond, body)
+
+-- Transform a list of elifs into a nested if-else structure
+transformIf :: Expression -> Body -> [(Expression, Body)] -> Maybe Body -> Statement
+transformIf cond thenBody elifBodies elseBody =
+  case elifBodies of
+    [] -> If cond thenBody elseBody
+    (elifCond, elifBody) : rest ->
+      If cond thenBody (Just [transformIf elifCond elifBody rest elseBody])
+
+-------------------------------------------------------------------------------
+-- Type Declaration: type <name> = { ... } | [size: T] | <A, B, C>
+-------------------------------------------------------------------------------
+
+parseTypeDeclaration :: Parser Statement
+parseTypeDeclaration = do
+  _ <- matchTokenType TType
+  name <- parseIdentifier
+  _ <- matchTokenType TEqSign
+  tyDef <- parseTypeDefinition name
+  _ <- matchTokenType TSemicolon
+  return $ TypeDeclaration tyDef
+
+-------------------------------------------------------------------------------
+-- Standalone Function Call: <func_name>(<args>);
+-------------------------------------------------------------------------------
+parseStandaloneFunctionCall :: Parser Statement
+parseStandaloneFunctionCall = do
+  name <- parseIdentifier
+  _ <- matchTokenType TOpenParen
+  args <- parseExpression `sepBy` matchTokenType TComma
+  _ <- matchTokenType TCloseParen
+  _ <- matchTokenType TSemicolon
+  return $ StandaloneFunctionCall name args
+
+-------------------------------------------------------------------------------
+-- Variable Reassignment: <name> = <expr>;
+-------------------------------------------------------------------------------
+parseVariableReAssignment :: Parser Statement
+parseVariableReAssignment = do
+  name <- parseIdentifier
+  _ <- matchTokenType TEqSign
+  expr <- parseExpression
+  _ <- matchTokenType TSemicolon
+  return $ VariableReAssignment name expr
+
+-------------------------------------------------------------------------------
+-- Parse Type Definitions
+-------------------------------------------------------------------------------
+parseTypeDefinition :: String -> Parser TypeDefinition
+parseTypeDefinition name =
+  choice
+    [ parseStructDefinition name,
+      parseArrayDefinition name,
+      parseEnumDefinition name,
+      parseAliasDefinition name
+    ]
+
+-------------------------------------------------------------------------------
+-- Parse Struct Definition: { <fields> }
+-------------------------------------------------------------------------------
+parseStructDefinition :: String -> Parser TypeDefinition
+parseStructDefinition name = do
+  _ <- matchTokenType TOpenBrace
+  fields <- parseField `sepBy` matchTokenType TComma
+  _ <- matchTokenType TCloseBrace
+  return $ StructDeclaration name (Struct fields)
+
+-------------------------------------------------------------------------------
+-- Parse Array Definition: [<size>: <type>]
+-------------------------------------------------------------------------------
+parseArrayDefinition :: String -> Parser TypeDefinition
+parseArrayDefinition name = do
+  _ <- matchTokenType TOpenBracket
+  size <- fromIntegral <$> parseIntLiteral
+  _ <- matchTokenType TColon
+  ty <- parseType
+  _ <- matchTokenType TCloseBracket
+  return $ ArrayDeclaration name (size, ty)
+
+-------------------------------------------------------------------------------
+-- Parse Enum Definition: <variant1, variant2, ...>
+-------------------------------------------------------------------------------
+parseEnumDefinition :: String -> Parser TypeDefinition
+parseEnumDefinition name = do
+  _ <- matchTokenType TLessThan
+  variants <- parseIdentifier `sepBy` matchTokenType TComma
+  _ <- matchTokenType TGreaterThan
+  return $ EnumDeclaration name variants
+
+-------------------------------------------------------------------------------
+-- Parse Alias Definition: <type>
+-------------------------------------------------------------------------------
+
+parseAliasDefinition :: String -> Parser TypeDefinition
+parseAliasDefinition name = do
+  ty <- parseType
+  return $ AliasDeclaration name ty
+
+-------------------------------------------------------------------------------
+-- Return Statement: return <expr>;
+-------------------------------------------------------------------------------
+parseReturnStatement :: Parser Statement
+parseReturnStatement = do
+  _ <- matchTokenType TReturn
+  expr <- parseExpression
+  _ <- matchTokenType TSemicolon
+  return $ ReturnStatement expr
+
+-------------------------------------------------------------------------------
+-- Parse Fields: <name>: <type>
+-------------------------------------------------------------------------------
+parseField :: Parser Field
+parseField = do
+  name <- parseIdentifier
+  _ <- matchTokenType TColon
+  ty <- parseType
+  return (name, ty)
+
+-------------------------------------------------------------------------------
+-- Parse Expressions
+-------------------------------------------------------------------------------
+parseExpression :: Parser Expression
+parseExpression = makeExprParser parseTerm operatorTable
+
+parseTerm :: Parser Expression
+parseTerm =
+  choice
+    [ parseParenthesis,
+      parseLiteral,
+      parseVariable
+    ]
+
+-------------------------------------------------------------------------------
+-- Parse Parenthesis: ( <expr> )
+-------------------------------------------------------------------------------
+parseParenthesis :: Parser Expression
+parseParenthesis = between (matchTokenType TOpenParen) (matchTokenType TCloseParen) parseExpression
+
+-------------------------------------------------------------------------------
+-- Parse Literals
+-------------------------------------------------------------------------------
+parseLiteral :: Parser Expression
+parseLiteral = do
+  tok <- matchToken isLiteral
+  case tokenType tok of
+    TIntLit n -> return $ ELiteral (IntLiteral $ fromIntegral n)
+    TFloatLit f -> return $ ELiteral (FloatLiteral f)
+    _ -> fail "Unexpected token, expected literal"
+  where
+    isLiteral (TIntLit _) = True
+    isLiteral (TFloatLit _) = True
+    isLiteral _ = False
+
+parseVariable :: Parser Expression
+parseVariable = do
+  tok <- matchToken isIdent
+  case tokenType tok of
+    TIdent name -> return $ Variable name
+    _ -> fail "Unexpected token, expected identifier"
+  where
+    isIdent (TIdent _) = True
+    isIdent _ = False
+
+operatorTable :: [[Operator Parser Expression]]
+operatorTable =
+  [ [ Prefix (UnaryOp Negate <$ matchTokenType TNot),
+      Prefix (UnaryOp Dereference <$ matchTokenType TDereference),
+      Prefix (UnaryOp AddressOf <$ matchTokenType TAddressOf),
+      Prefix (UnaryOp BitNot <$ matchTokenType TNor)
+    ],
+    [ InfixL (BinaryOp Mul <$ matchTokenType TMult),
+      InfixL (BinaryOp Div <$ matchTokenType TDiv),
+      InfixL (BinaryOp Mod <$ matchTokenType TMod)
+    ],
+    [ InfixL (BinaryOp Add <$ matchTokenType TPlus),
+      InfixL (BinaryOp Sub <$ matchTokenType TMinus)
+    ],
+    [ InfixN (BinaryOp Eq <$ matchTokenType TEq),
+      InfixN (BinaryOp Neq <$ matchTokenType TNotEq),
+      InfixN (BinaryOp Lt <$ matchTokenType TLessThan),
+      InfixN (BinaryOp Gt <$ matchTokenType TGreaterThan),
+      InfixN (BinaryOp Le <$ matchTokenType TLessEq),
+      InfixN (BinaryOp Ge <$ matchTokenType TGreaterEq)
+    ],
+    [ InfixL (BinaryOp And <$ matchTokenType TAnd),
+      InfixL (BinaryOp Or <$ matchTokenType TOr)
+    ],
+    [ InfixL (BinaryOp BitAnd <$ matchTokenType TBitAnd),
+      InfixL (BinaryOp BitOr <$ matchTokenType TBitOr),
+      InfixL (BinaryOp BitXor <$ matchTokenType TBitXor)
+    ],
+    [ InfixL (BinaryOp Shl <$ matchTokenType TLShift),
+      InfixL (BinaryOp Shr <$ matchTokenType TRShift)
+    ]
+  ]
+
+-------------------------------------------------------------------------------
+-- Parse Type
+-------------------------------------------------------------------------------
+
+parseType :: Parser Type
+parseType =
+  choice
+    [ parsePrimitiveType,
+      parsePointerType,
+      parseCustomType
+    ]
+
+parsePrimitiveType :: Parser Type
+parsePrimitiveType = do
+  tok <- matchToken isPrimitive
+  case tokenType tok of
+    TIdent "i8" -> return $ PrimitiveType I8
+    TIdent "i16" -> return $ PrimitiveType I16
+    TIdent "i32" -> return $ PrimitiveType I32
+    TIdent "i64" -> return $ PrimitiveType I64
+    TIdent "u8" -> return $ PrimitiveType U8
+    TIdent "u16" -> return $ PrimitiveType U16
+    TIdent "u32" -> return $ PrimitiveType U32
+    TIdent "u64" -> return $ PrimitiveType U64
+    TIdent "f32" -> return $ PrimitiveType F32
+    TIdent "f64" -> return $ PrimitiveType F64
+    _ -> fail "Invalid type"
+  where
+    isPrimitive (TIdent "i8") = True
+    isPrimitive (TIdent "i16") = True
+    isPrimitive (TIdent "i32") = True
+    isPrimitive (TIdent "i64") = True
+    isPrimitive (TIdent "u8") = True
+    isPrimitive (TIdent "u16") = True
+    isPrimitive (TIdent "u32") = True
+    isPrimitive (TIdent "u64") = True
+    isPrimitive (TIdent "f32") = True
+    isPrimitive (TIdent "f64") = True
+    isPrimitive _ = False
+
+parsePointerType :: Parser Type
+parsePointerType = do
+  _ <- matchTokenType TMult
+  mutability <- optional (matchTokenType TMut)
+  ty <- parseType
+  return $ PointerType (if isJust mutability then Mutable else Immutable) ty
+
+parseCustomType :: Parser Type
+parseCustomType = do
+  tok <- matchToken isCustom
+  case tokenType tok of
+    TIdent name -> return $ CustomType name
+    _ -> fail "Custom type names must start with a capital letter"
+  where
+    isCustom (TIdent (c : _)) = isUpper c
+    isCustom _ = False
+
+-------------------------------------------------------------------------------
+-- Parse Block
+-------------------------------------------------------------------------------
+parseBlock :: Parser Body
+parseBlock = between (matchTokenType TOpenBrace) (matchTokenType TCloseBrace) (many parseStatement)
+
+-------------------------------------------------------------------------------
+-- Parse Identifiers and Literals
+-------------------------------------------------------------------------------
+parseIdentifier :: Parser String
+parseIdentifier = do
+  tok <- matchToken isIdent
+  case tokenType tok of
+    TIdent name -> return name
+    _ -> fail "Unexpected token, expected identifier"
+  where
+    isIdent (TIdent _) = True
+    isIdent _ = False
+
+parseIntLiteral :: Parser Word64
+parseIntLiteral = do
+  tok <- matchToken isInt
+  case tokenType tok of
+    TIntLit n ->
+      if n > toInteger (maxBound :: Word64)
+        then fail "Integer literal too large"
+        else return (fromIntegral n)
+    _ -> fail "Unexpected token, expected integer literal"
+  where
+    isInt (TIntLit _) = True
+    isInt _ = False
+
+examplemain :: IO ()
+examplemain = do
+  let testInputs =
+        [ "x = 5;",
+          "let x: i32 = 5;",
+          "fn add(a: i32, b: i32) -> i32 { return a + b; }",
+          "while (x < 10) { x = x + 1; }",
+          "if (x == 0) { x = 1; } else { x = 0; }",
+          "type Point = { x: i32, y: i32 };",
+          "type IntArray = [10: i32];",
+          "type Color = <Red, Green, Blue>;",
+          "type Ptr = *mut i32;"
+        ]
+  mapM_ runTest testInputs
+  where
+    runTest input = do
+      putStrLn $ "Input: " ++ input
+      case runLexer input of
+        Left err -> putStrLn $ "lexer: " ++ errorBundlePretty err
+        Right tokens -> case runParser parseProgram "FILE" (Lexer.TokenStream tokens) of
+          Left err -> do
+            putStrLn $ "tokens: " ++ show tokens
+            putStrLn $ "parser: " ++ errorBundlePretty err
+          Right result -> putStrLn $ "Parsed successfully: " ++ show result
+      putStrLn ""
+    runLexer = runParser Lexer.tokens "<test>"

--- a/package.yaml
+++ b/package.yaml
@@ -72,8 +72,11 @@ tests:
     dependencies:
     - QuickCheck
     - hspec
+    - base
     - hspec-discover
     - megaparsec
     - text
     - containers
+    - bytestring
+    - parser-combinators
     - xenon

--- a/test/LexerQuickCheckSpec.hs
+++ b/test/LexerQuickCheckSpec.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module LexerQuickCheckSpec (main, spec) where
+
+import Test.Hspec
+import Test.QuickCheck
+import Parser.System.Lexer
+import Data.Void
+import qualified Text.Megaparsec as MP
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "Lexer.tokens with QuickCheck" $ do
+    it "should parse identifiers with valid names" $ property $
+      \(ValidIdentifier name) -> do
+        let result = runLexer name
+        case result of
+          Right [Token _ (TIdent parsedName), Token _ TEOF] -> parsedName `shouldBe` name
+          _ -> expectationFailure $ "Unexpected result: " ++ show result
+
+    it "should parse valid integer literals" $ property $
+      \(NonNegative n :: NonNegative Integer) -> do
+        let input = show n
+        let result = runLexer input
+        case result of
+          Right [Token _ (TIntLit parsedNum), Token _ TEOF] -> parsedNum `shouldBe` n
+          _ -> expectationFailure $ "Unexpected result: " ++ show result
+
+    it "should parse valid float literals" $ property $
+      \(Positive f :: Positive Double) -> do
+        let input = show f
+        let result = runLexer input
+        case result of
+          Right [Token _ (TFloatLit parsedNum), Token _ TEOF] -> parsedNum `shouldBe` f
+          _ -> expectationFailure $ "Unexpected result: " ++ show result
+
+    it "should parse combinations of identifiers and literals" $ property $
+      \(ValidIdentifier name, NonNegative n :: NonNegative Integer) -> do
+        let input = name ++ " = " ++ show n ++ ";"
+        let result = runLexer input
+        case result of
+          Right [ Token _ (TIdent parsedName),
+                  Token _ TEqSign,
+                  Token _ (TIntLit parsedNum),
+                  Token _ TSemicolon,
+                  Token _ TEOF ] -> do
+            parsedName `shouldBe` name
+            parsedNum `shouldBe` n
+          _ -> expectationFailure $ "Unexpected result: " ++ show result
+
+-- Helper function to run the lexer
+runLexer :: String -> Either (MP.ParseErrorBundle String Void) [Token]
+runLexer = MP.runParser tokens "<quickcheck-test>"
+
+-- Arbitrary generator for valid identifiers
+newtype ValidIdentifier = ValidIdentifier String
+  deriving (Show, Eq)
+
+instance Arbitrary ValidIdentifier where
+  arbitrary = do
+    firstChar <- elements (['a'..'z'] ++ ['A'..'Z'])
+    rest <- listOf $ elements (['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ ['_'])
+    return $ ValidIdentifier (firstChar : rest)

--- a/test/LexerQuickCheckSpec.hs
+++ b/test/LexerQuickCheckSpec.hs
@@ -51,11 +51,9 @@ spec = do
             parsedNum `shouldBe` n
           _ -> expectationFailure $ "Unexpected result: " ++ show result
 
--- Helper function to run the lexer
 runLexer :: String -> Either (MP.ParseErrorBundle String Void) [Token]
 runLexer = MP.runParser tokens "<quickcheck-test>"
 
--- Arbitrary generator for valid identifiers
 newtype ValidIdentifier = ValidIdentifier String
   deriving (Show, Eq)
 

--- a/test/LexerSpec.hs
+++ b/test/LexerSpec.hs
@@ -146,10 +146,8 @@ spec = do
         Left err -> MP.errorBundlePretty err `shouldContain` "unexpected '#'"
         Right _ -> expectationFailure "Expected failure, but succeeded!"
 
--- Helper function to run the lexer and simplify error handling
 runLexer :: String -> Either (MP.ParseErrorBundle String Void) [Token]
 runLexer = MP.runParser tokens "<test>"
 
--- Helper to construct SourcePos for tokens
 pos :: Int -> Int -> MP.SourcePos
 pos line col = MP.SourcePos "<test>" (MP.mkPos line) (MP.mkPos col)

--- a/test/LexerSpec.hs
+++ b/test/LexerSpec.hs
@@ -1,0 +1,155 @@
+module LexerSpec (main, spec) where
+
+import Data.Void
+import Parser.System.Lexer
+import Test.Hspec
+import qualified Text.Megaparsec as MP
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "Lexer.tokens" $ do
+    it "should correctly tokenize simple keywords" $ do
+      runLexer "let"
+        `shouldBe` Right
+          [ Token (pos 1 1) TLet,
+            Token (pos 1 4) TEOF
+          ]
+
+      runLexer "fn"
+        `shouldBe` Right
+          [ Token (pos 1 1) TFn,
+            Token (pos 1 3) TEOF
+          ]
+
+    it "should tokenize integers and floats" $ do
+      runLexer "42"
+        `shouldBe` Right
+          [ Token (pos 1 1) (TIntLit 42),
+            Token (pos 1 3) TEOF
+          ]
+
+      runLexer "-3.14"
+        `shouldBe` Right
+          [ Token (pos 1 1) (TFloatLit (-3.14)),
+            Token (pos 1 6) TEOF
+          ]
+
+    it "should tokenize identifiers" $ do
+      runLexer "x"
+        `shouldBe` Right
+          [ Token (pos 1 1) (TIdent "x"),
+            Token (pos 1 2) TEOF
+          ]
+
+      runLexer "hello_world"
+        `shouldBe` Right
+          [ Token (pos 1 1) (TIdent "hello_world"),
+            Token (pos 1 12) TEOF
+          ]
+
+    it "should tokenize symbols" $ do
+      runLexer ":"
+        `shouldBe` Right
+          [ Token (pos 1 1) TColon,
+            Token (pos 1 2) TEOF
+          ]
+
+      runLexer ";"
+        `shouldBe` Right
+          [ Token (pos 1 1) TSemicolon,
+            Token (pos 1 2) TEOF
+          ]
+
+      runLexer "->"
+        `shouldBe` Right
+          [ Token (pos 1 1) TArrow,
+            Token (pos 1 3) TEOF
+          ]
+
+    it "should skip comments and whitespace" $ do
+      runLexer "let x = 42; // this is a comment"
+        `shouldBe` Right
+          [ Token (pos 1 1) TLet,
+            Token (pos 1 5) (TIdent "x"),
+            Token (pos 1 7) TEqSign,
+            Token (pos 1 9) (TIntLit 42),
+            Token (pos 1 11) TSemicolon,
+            Token (pos 1 33) TEOF
+          ]
+
+      runLexer "/* block comment */let x = 42;"
+        `shouldBe` Right
+          [ Token (pos 1 20) TLet,
+            Token (pos 1 24) (TIdent "x"),
+            Token (pos 1 26) TEqSign,
+            Token (pos 1 28) (TIntLit 42),
+            Token (pos 1 30) TSemicolon,
+            Token (pos 1 31) TEOF
+          ]
+
+    it "should parse very long numbers" $ do
+      runLexer "123456789012345678901234567890"
+        `shouldBe` Right
+          [ Token (pos 1 1) (TIntLit 123456789012345678901234567890),
+            Token (pos 1 31) TEOF
+          ]
+
+      runLexer "123456789012345678901234567890.123456789012345678901234567890"
+        `shouldBe` Right
+          [ Token (pos 1 1) (TFloatLit 123456789012345678901234567890.123456789012345678901234567890),
+            Token (pos 1 62) TEOF
+          ]
+
+    it "should handle normal expressions" $ do
+      runLexer "let x: i32 = 42;"
+        `shouldBe` Right
+          [ Token (pos 1 1) TLet,
+            Token (pos 1 5) (TIdent "x"),
+            Token (pos 1 6) TColon,
+            Token (pos 1 8) (TIdent "i32"),
+            Token (pos 1 12) TEqSign,
+            Token (pos 1 14) (TIntLit 42),
+            Token (pos 1 16) TSemicolon,
+            Token (pos 1 17) TEOF
+          ]
+
+      runLexer "fn add(a: i32, b: i32) -> i32 { return a + b; }"
+        `shouldBe` Right
+          [ Token (pos 1 1) TFn,
+            Token (pos 1 4) (TIdent "add"),
+            Token (pos 1 7) TOpenParen,
+            Token (pos 1 8) (TIdent "a"),
+            Token (pos 1 9) TColon,
+            Token (pos 1 11) (TIdent "i32"),
+            Token (pos 1 14) TComma,
+            Token (pos 1 16) (TIdent "b"),
+            Token (pos 1 17) TColon,
+            Token (pos 1 19) (TIdent "i32"),
+            Token (pos 1 22) TCloseParen,
+            Token (pos 1 24) TArrow,
+            Token (pos 1 27) (TIdent "i32"),
+            Token (pos 1 31) TOpenBrace,
+            Token (pos 1 33) TReturn,
+            Token (pos 1 40) (TIdent "a"),
+            Token (pos 1 42) TPlus,
+            Token (pos 1 44) (TIdent "b"),
+            Token (pos 1 45) TSemicolon,
+            Token (pos 1 47) TCloseBrace,
+            Token (pos 1 48) TEOF
+          ]
+
+    it "should handle invalid input gracefully" $ do
+      case runLexer "#" of
+        Left err -> MP.errorBundlePretty err `shouldContain` "unexpected '#'"
+        Right _ -> expectationFailure "Expected failure, but succeeded!"
+
+-- Helper function to run the lexer and simplify error handling
+runLexer :: String -> Either (MP.ParseErrorBundle String Void) [Token]
+runLexer = MP.runParser tokens "<test>"
+
+-- Helper to construct SourcePos for tokens
+pos :: Int -> Int -> MP.SourcePos
+pos line col = MP.SourcePos "<test>" (MP.mkPos line) (MP.mkPos col)

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module ParserSpec (main, spec) where
+
+import Test.Hspec
+import Test.QuickCheck
+import Data.Void
+import Text.Megaparsec (parse, errorBundlePretty, ParseErrorBundle)
+import qualified Parser.System.Lexer as Lexer
+import Parser.System.Parser
+import Parser.Data.Ast
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+  describe "Parser tests" $ do
+    it "parses variable declarations correctly" $ do
+      let input = "let x: i32 = 42;"
+      runParserTest input `shouldBe` Right (Program [VariableDeclaration "x" (PrimitiveType Immutable I32) (Just (ELiteral (IntLiteral 42)))])
+    
+    it "parses negative integer literals correctly" $ do
+      let input = "let x: i32 = -42;"
+      runParserTest input `shouldBe` Right (Program [VariableDeclaration "x" (PrimitiveType Immutable I32) (Just (ELiteral (IntLiteral (-42))))])
+
+    it "parses basic arithmetic expressions correctly" $ do
+      let addition = "let x: i32 = 5 + 3 + 2;"
+      runParserTest addition `shouldSatisfy` isRight
+      
+      let subtraction = "let x: i32 = 5 - 3 - 2;"
+      runParserTest subtraction `shouldSatisfy` isRight
+
+      let multiplication = "let x: i32 = 5 * 3 * 2;"
+      runParserTest multiplication `shouldSatisfy` isRight
+
+      let division = "let x: f32 = 5 / 3 / 2;"
+      runParserTest division `shouldSatisfy` isRight
+
+      let modulo = "let x: i32 = 5 % 3 % 2;"
+      runParserTest modulo `shouldSatisfy` isRight
+
+    it "parses mixed arithmetic expressions correctly" $ do
+      let input1 = "let x: i32 = 5 + 3 * 2;"
+      runParserTest input1 `shouldSatisfy` isRight
+
+      let input2 = "let x: i32 = 5 * 3 + 2;"
+      runParserTest input2 `shouldSatisfy` isRight
+
+      let input3 = "let x: i32 = 5 * (3 + 2);"
+      runParserTest input3 `shouldSatisfy` isRight
+
+      let input4 = "let x: i32 = (5 - 2) * 3;"
+      runParserTest input4 `shouldSatisfy` isRight
+
+    it "parses function declarations correctly" $ do
+      let input = "fn add(a: i32, b: i32) -> i32 { return a + b; }"
+      runParserTest input `shouldSatisfy` isRight
+
+    it "parses while loops correctly" $ do
+      let input = "while (x < 10) { x = x + 1; }"
+      runParserTest input `shouldSatisfy` isRight
+
+    it "parses if statements with else correctly" $ do
+      let input = "if (x == 0) { x = 1; } else { x = 0; }"
+      runParserTest input `shouldSatisfy` isRight
+
+    it "parses struct type declarations correctly" $ do
+      let input = "type Point = { x: i32, y: i32 };"
+      runParserTest input `shouldBe` Right (Program [TypeDeclaration "Point" (StructType Immutable (Struct [("x",PrimitiveType Immutable I32),("y",PrimitiveType Immutable I32)]))])
+
+    it "parses array type declarations correctly" $ do
+      let input = "type IntArray = [10: i32];"
+      runParserTest input `shouldSatisfy` isRight
+
+    it "parses enum type declarations correctly" $ do
+      let input = "type Color = <Red, Green, Blue>;"
+      runParserTest input `shouldSatisfy` isRight
+
+    it "handles reassignment correctly" $ do
+      let input = "let x: i32 = 0; x = 5;"
+      runParserTest input `shouldSatisfy` isRight
+
+  describe "QuickCheck property tests" $ do
+    it "always parses valid variable declarations" $ property $ 
+      forAll genVariableDeclaration $ \(name, value) ->
+        let input = "let " ++ name ++ ": i32 = " ++ show value ++ ";" 
+         in isRight (runParserTest input)
+
+-------------------------------------------------------------------------------
+-- Helper functions
+-------------------------------------------------------------------------------
+
+runParserTest :: String -> Either String Program
+runParserTest input = case runLexer input of
+  Left err -> Left $ "Lexer error: " ++ errorBundlePretty err
+  Right tokens -> case parse parseProgram "test" (Lexer.TokenStream tokens) of
+    Left err -> Left $ "Parser error: " ++ errorBundlePretty err
+    Right result -> Right result
+
+runLexer :: String -> Either (ParseErrorBundle String Void) [Lexer.Token]
+runLexer = parse Lexer.tokens "test"
+
+isRight :: Either a b -> Bool
+isRight (Right _) = True
+isRight _ = False
+
+-------------------------------------------------------------------------------
+-- Arbitrary Generators for QuickCheck
+-------------------------------------------------------------------------------
+
+-- Generate valid variable names (alphanumeric starting with a lowercase letter)
+genVariableName :: Gen String
+genVariableName = (:) <$> elements ['a'..'z'] <*> listOf (elements $ ['a'..'z'] ++ ['0'..'9'] ++ ['_'])
+
+-- Generate random integer values
+genIntValue :: Gen Int
+genIntValue = arbitrary --`suchThat` (>= 0)
+
+-- Combine to generate variable declarations
+genVariableDeclaration :: Gen (String, Int)
+genVariableDeclaration = (,) <$> genVariableName <*> genIntValue

--- a/xenon.cabal
+++ b/xenon.cabal
@@ -25,6 +25,7 @@ library
   exposed-modules:
       Parser.Data.Ast
       Parser.Data.ParserS
+      Parser.System.Lexer
       Parser.System.Parser
       Utils.Control.Convert
       Utils.Data.Result
@@ -48,7 +49,6 @@ library
 executable compiler
   main-is: Main.hs
   other-modules:
-      ModuleData
       Paths_xenon
   autogen-modules:
       Paths_xenon
@@ -89,7 +89,8 @@ test-suite test
   main-is: Main.hs
   other-modules:
       ExampleSpec
-      ParserSpec
+      LexerQuickCheckSpec
+      LexerSpec
       Paths_xenon
   autogen-modules:
       Paths_xenon
@@ -98,13 +99,13 @@ test-suite test
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck
-    , base >=4.7 && <5
+    , base
     , bytestring
     , containers
     , hspec
     , hspec-discover
     , megaparsec
-    , parser-combinators >=1.3.0
+    , parser-combinators
     , text
     , xenon
   default-language: Haskell2010

--- a/xenon.cabal
+++ b/xenon.cabal
@@ -91,6 +91,7 @@ test-suite test
       ExampleSpec
       LexerQuickCheckSpec
       LexerSpec
+      ParserSpec
       Paths_xenon
   autogen-modules:
       Paths_xenon


### PR DESCRIPTION
## TODO:
*before merge*
- [x] Heavily Test the Parser (Hspec + QuickCheck)
- [ ] Unary operator '-' correct parsing. converting litterals to negative ones won't be done in the front-end, this will be an optimisation step.

*if i have time, in a next pr*
- [x]  Meaningful error messages on bad parsing -> error message merging lexer + parser

Wil proably be on another PR:
- member access using the dot symbol `.`
- positionnal access `array[1]`

## A few important changes are beeing made to the AST:
- Assignment operator `=` which was previously an operator is now a construct.
- Conditions (`if` `else` `elif`) are represent as `if` and optionnal `else` (elif is just syntactic sugar) 
- BitNot `~` has been fixed and is now an Unary operator
- Literals have changed type:
```hs
data Literal
  = IntLiteral Word64
  | FloatLiteral Double
  ``` 
- Arrays are now correctly expressed as <amount> + <type>
- Type declarations and type usage are now merged in a single data type.
