### PR TITLE
23 handle negative numbers in parser & lexer

### DIFF
--- a/lib/Parser/System/Lexer.hs
+++ b/lib/Parser/System/Lexer.hs
@@ -159,7 +159,7 @@ keyword :: String -> TokenType -> Lexer Token
 keyword str ttype = lexeme . MP.try $ do
   pos <- MP.getSourcePos
   _ <- C.string str
-  MP.notFollowedBy C.alphaNumChar
+  MP.notFollowedBy (C.alphaNumChar MP.<|> C.char '_')
   return $ Token pos ttype
 
 -------------------------------------------------------------------------------

--- a/lib/Parser/System/Parser.hs
+++ b/lib/Parser/System/Parser.hs
@@ -256,8 +256,8 @@ operatorTable =
   [ [ Prefix (UnaryOp Negate <$ matchTokenType TNot),
       Prefix (UnaryOp Dereference <$ matchTokenType TDereference),
       Prefix (UnaryOp AddressOf <$ matchTokenType TAddressOf),
-      Prefix (UnaryOp BitNot <$ matchTokenType TNor)
-      -- Prefix (UnaryOp Negative <$ matchTokenType TMinus) // TODO implement negative operator
+      Prefix (UnaryOp BitNot <$ matchTokenType TNor),
+      Prefix (UnaryOp Negative <$ matchTokenType TMinus) -- TODO implement negative operator
     ],
     [ InfixL (BinaryOp Mul <$ matchTokenType TMult),
       InfixL (BinaryOp Div <$ matchTokenType TDiv),

--- a/test/LexerQuickCheckSpec.hs
+++ b/test/LexerQuickCheckSpec.hs
@@ -14,12 +14,12 @@ main = hspec spec
 spec :: Spec
 spec = do
   describe "Lexer.tokens with QuickCheck" $ do
-    -- it "should parse identifiers with valid names" $ property $
-    --   \(ValidIdentifier name) -> do
-    --     let result = runLexer name
-    --     case result of
-    --       Right [Token _ (TIdent parsedName), Token _ TEOF] -> parsedName `shouldBe` name
-    --       _ -> expectationFailure $ "Unexpected result: " ++ show result
+    it "should parse identifiers with valid names" $ property $
+      \(ValidIdentifier name) -> do
+        let result = runLexer name
+        case result of
+          Right [Token _ (TIdent parsedName), Token _ TEOF] -> parsedName `shouldBe` name
+          _ -> expectationFailure $ "Unexpected result: " ++ show result
 
     it "should parse valid integer literals" $ property $
       \(NonNegative n :: NonNegative Integer) -> do

--- a/test/LexerQuickCheckSpec.hs
+++ b/test/LexerQuickCheckSpec.hs
@@ -59,6 +59,6 @@ newtype ValidIdentifier = ValidIdentifier String
 
 instance Arbitrary ValidIdentifier where
   arbitrary = do
-    firstChar <- elements (['a'..'z'] ++ ['A'..'Z'])
+    firstChar <- elements (['a'..'z'] ++ ['A'..'Z'] ++ ['_'])
     rest <- listOf $ elements (['a'..'z'] ++ ['A'..'Z'] ++ ['0'..'9'] ++ ['_'])
     return $ ValidIdentifier (firstChar : rest)

--- a/test/LexerSpec.hs
+++ b/test/LexerSpec.hs
@@ -31,11 +31,11 @@ spec = do
             Token (pos 1 3) TEOF
           ]
 
-      -- runLexer "-3.14"
-      --   `shouldBe` Right
-      --     [ Token (pos 1 1) (TFloatLit (-3.14)),
-      --       Token (pos 1 6) TEOF
-      --     ]
+      runLexer "-3.14"
+        `shouldBe` Right
+          [ Token (pos 1 1) TMinus, Token (pos 1 2) (TFloatLit 3.14),
+            Token (pos 1 6) TEOF
+          ]
 
     it "should tokenize identifiers" $ do
       runLexer "x"

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -2,13 +2,13 @@
 
 module ParserSpec (main, spec) where
 
-import Test.Hspec
--- import Test.QuickCheck
+import Test.QuickCheck hiding (Negative)
 import Data.Void
-import Text.Megaparsec (parse, errorBundlePretty, ParseErrorBundle)
+import Parser.Data.Ast
 import qualified Parser.System.Lexer as Lexer
 import Parser.System.Parser
-import Parser.Data.Ast
+import Test.Hspec
+import Text.Megaparsec (ParseErrorBundle, errorBundlePretty, parse)
 
 main :: IO ()
 main = hspec spec
@@ -19,15 +19,15 @@ spec = do
     it "parses variable declarations correctly" $ do
       let input = "let x: i32 = 42;"
       runParserTest input `shouldBe` Right (Program [VariableDeclaration "x" (PrimitiveType Immutable I32) (Just (ELiteral (IntLiteral 42)))])
-    
-    -- it "parses negative integer literals correctly" $ do
-    --   let input = "let x: i32 = -42;"
-    --   runParserTest input `shouldBe` Right (Program [VariableDeclaration "x" (PrimitiveType Immutable I32) (Just (ELiteral (IntLiteral (-42))))])
+
+    it "parses negative integer literals correctly" $ do
+      let input = "let x: i32 = -42;"
+      runParserTest input `shouldBe` Right (Program [VariableDeclaration "x" (PrimitiveType Immutable I32) (Just (UnaryOp Negative (ELiteral (IntLiteral 42))))])
 
     it "parses basic arithmetic expressions correctly" $ do
       let addition = "let x: i32 = 5 + 3 + 2;"
       runParserTest addition `shouldSatisfy` isRight
-      
+
       let subtraction = "let x: i32 = 5 - 3 - 2;"
       runParserTest subtraction `shouldSatisfy` isRight
 
@@ -42,16 +42,58 @@ spec = do
 
     it "parses mixed arithmetic expressions correctly" $ do
       let input1 = "let x: i32 = 5 + 3 * 2;"
-      runParserTest input1 `shouldSatisfy` isRight
+      runParserTest input1
+        `shouldBe` Right
+          ( Program
+              [ VariableDeclaration
+                  "x"
+                  (PrimitiveType Immutable I32)
+                  ( Just
+                      (BinaryOp Add (ELiteral (IntLiteral 5)) (BinaryOp Mul (ELiteral (IntLiteral 3)) (ELiteral (IntLiteral 2))))
+                  )
+              ]
+          )
 
       let input2 = "let x: i32 = 5 * 3 + 2;"
-      runParserTest input2 `shouldSatisfy` isRight
+      runParserTest input2
+        `shouldBe` Right
+          ( Program
+              [ VariableDeclaration
+                  "x"
+                  (PrimitiveType Immutable I32)
+                  ( Just
+                      (BinaryOp Add (BinaryOp Mul (ELiteral (IntLiteral 5)) (ELiteral (IntLiteral 3))) (ELiteral (IntLiteral 2)))
+                  )
+              ]
+          )
 
       let input3 = "let x: i32 = 5 * (3 + 2);"
       runParserTest input3 `shouldSatisfy` isRight
 
       let input4 = "let x: i32 = (5 - 2) * 3;"
       runParserTest input4 `shouldSatisfy` isRight
+
+    it "parses complex operations using negative literals correctly" $ do
+      let input = "let x: i32 = 5 + -3 * 2;"
+      runParserTest input
+        `shouldBe` Right
+          ( Program
+              [ VariableDeclaration
+                  "x"
+                  (PrimitiveType Immutable I32)
+                  ( Just
+                      ( BinaryOp
+                          Add
+                          (ELiteral (IntLiteral 5))
+                          (BinaryOp Mul (UnaryOp Negative (ELiteral (IntLiteral 3))) (ELiteral (IntLiteral 2)))
+                      )
+                  )
+              ]
+          )
+
+      let expected_output = Right (Program [VariableDeclaration "x" (PrimitiveType Immutable I32) (Just (BinaryOp Sub (ELiteral (IntLiteral 3)) (UnaryOp Negative (ELiteral (IntLiteral 2)))))])
+      runParserTest "let x: i32 = 3 -- 2;" `shouldBe` expected_output
+      runParserTest "let x: i32 = 3 - -2;" `shouldBe` expected_output
 
     it "parses function declarations correctly" $ do
       let input = "fn add(a: i32, b: i32) -> i32 { return a + b; }"
@@ -67,7 +109,7 @@ spec = do
 
     it "parses struct type declarations correctly" $ do
       let input = "type Point = { x: i32, y: i32 };"
-      runParserTest input `shouldBe` Right (Program [TypeDeclaration "Point" (StructType Immutable (Struct [("x",PrimitiveType Immutable I32),("y",PrimitiveType Immutable I32)]))])
+      runParserTest input `shouldBe` Right (Program [TypeDeclaration "Point" (StructType Immutable (Struct [("x", PrimitiveType Immutable I32), ("y", PrimitiveType Immutable I32)]))])
 
     it "parses array type declarations correctly" $ do
       let input = "type IntArray = [10: i32];"
@@ -81,11 +123,11 @@ spec = do
       let input = "let x: i32 = 0; x = 5;"
       runParserTest input `shouldSatisfy` isRight
 
-  -- describe "QuickCheck property tests" $ do
-  --   it "always parses valid variable declarations" $ property $ 
-  --     forAll genVariableDeclaration $ \(name, value) ->
-  --       let input = "let " ++ name ++ ": i32 = " ++ show value ++ ";" 
-  --        in isRight (runParserTest input)
+  describe "QuickCheck property tests" $ do
+    it "always parses valid variable declarations" $ property $
+      forAll genVariableDeclaration $ \(name, value) ->
+        let input = "let " ++ name ++ ": i32 = " ++ show value ++ ";"
+        in isRight (runParserTest input) -- if negative will output (UnaryOp Negative (ELiteral (IntLiteral ...)))
 
 -------------------------------------------------------------------------------
 -- Helper functions
@@ -109,14 +151,11 @@ isRight _ = False
 -- Arbitrary Generators for QuickCheck
 -------------------------------------------------------------------------------
 
--- -- Generate valid variable names (alphanumeric starting with a lowercase letter)
--- genVariableName :: Gen String
--- genVariableName = (:) <$> elements ['a'..'z'] <*> listOf (elements $ ['a'..'z'] ++ ['0'..'9'] ++ ['_'])
+genVariableName :: Gen String
+genVariableName = (:) <$> elements ['a'..'z'] <*> listOf (elements $ ['a'..'z'] ++ ['0'..'9'] ++ ['_'])
 
--- -- Generate random integer values
--- genIntValue :: Gen Int
--- genIntValue = arbitrary --`suchThat` (>= 0)
+genIntValue :: Gen Int
+genIntValue = arbitrary --`suchThat` (>= 0)
 
--- -- Combine to generate variable declarations
--- genVariableDeclaration :: Gen (String, Int)
--- genVariableDeclaration = (,) <$> genVariableName <*> genIntValue
+genVariableDeclaration :: Gen (String, Int)
+genVariableDeclaration = (,) <$> genVariableName <*> genIntValue


### PR DESCRIPTION
Like I said a lot previously:
**This only fixes an issue that shouldn't have existed.**

## Example
**input:** "-3.14"
Negative numbers are lexed as :
**lexer output:**  `TMinus TFloatLit 3.14`
Negative numbers are parsed as:
**parser output:** `UnaryOp Negative (ELiteral (FloatLiteral 3.14)))`

what needs to be done to make theses changes meaningfull:
- [ ] Solve all `UnaryOp Negative` to use the `BinaryOp` version (This should be done in the optimizer step). And this step should transform the above example into a Literal that contains a negative number.
While beeing at it it could solve all types of expressions that don't contain mutable variables (that are not function parameters)